### PR TITLE
VWA 84: Add PostTag and ForumDiscussionTag junction tables for user tagging

### DIFF
--- a/migrations/20260329000001-create-post-tags.js
+++ b/migrations/20260329000001-create-post-tags.js
@@ -1,0 +1,37 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('post_tags', {
+      post_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: 'posts',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+    });
+
+    await queryInterface.addIndex('post_tags', ['post_id', 'user_id']);
+    await queryInterface.addIndex('post_tags', ['user_id']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('post_tags');
+  },
+};

--- a/migrations/20260329000002-create-forum-discussion-tags.js
+++ b/migrations/20260329000002-create-forum-discussion-tags.js
@@ -1,0 +1,37 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('forum_discussion_tags', {
+      forum_discussion_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: 'forum_discussions',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+    });
+
+    await queryInterface.addIndex('forum_discussion_tags', ['forum_discussion_id', 'user_id']);
+    await queryInterface.addIndex('forum_discussion_tags', ['user_id']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('forum_discussion_tags');
+  },
+};

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -34,7 +34,7 @@ import {CommunityJoinRequest} from './communityJoinRequest';
 // import {ExpiryTime} from './expiryTime';
 // import {UserNotificationTypes} from './user_notification_types';
 import { CommunityRole } from './communityRole.model';
-import {CommunityInterest, BlogInterest} from './junction-tables';
+import {CommunityInterest, BlogInterest, PostTag, ForumDiscussionTag} from './junction-tables';
 import {ForumDiscussion} from './forumDiscussion';
 
 export default [
@@ -67,6 +67,8 @@ export default [
   CommunityRole,
   CommunityInterest,
   BlogInterest,
+  PostTag,
+  ForumDiscussionTag,
   ForumDiscussion,
 //   Forum,
 //   Place,

--- a/src/database/junction-tables.ts
+++ b/src/database/junction-tables.ts
@@ -14,6 +14,8 @@ import { Community } from './communities';
 import { Interest } from './interest';
 import { User } from './user';
 import { Blog } from './blog';
+import { Post } from './post';
+import { ForumDiscussion } from './forumDiscussion';
 
 // Example: Community-Interest junction table (if you needed more than just IDs)
 @Table({
@@ -140,9 +142,63 @@ export class BlogInterest extends Model {
   interestId!: string;
 }
 
+@Table({
+  modelName: 'PostTag',
+  tableName: 'post_tags',
+  timestamps: false,
+  underscored: true,
+} as TableOptions<PostTag>)
+export class PostTag extends Model {
+  @PrimaryKey
+  @ForeignKey(() => Post)
+  @Column({
+    type: DataType.UUID,
+    allowNull: false,
+    field: 'post_id',
+  })
+  postId!: string;
+
+  @PrimaryKey
+  @ForeignKey(() => User)
+  @Column({
+    type: DataType.UUID,
+    allowNull: false,
+    field: 'user_id',
+  })
+  userId!: string;
+}
+
+@Table({
+  modelName: 'ForumDiscussionTag',
+  tableName: 'forum_discussion_tags',
+  timestamps: false,
+  underscored: true,
+} as TableOptions<ForumDiscussionTag>)
+export class ForumDiscussionTag extends Model {
+  @PrimaryKey
+  @ForeignKey(() => ForumDiscussion)
+  @Column({
+    type: DataType.UUID,
+    allowNull: false,
+    field: 'forum_discussion_id',
+  })
+  forumDiscussionId!: string;
+
+  @PrimaryKey
+  @ForeignKey(() => User)
+  @Column({
+    type: DataType.UUID,
+    allowNull: false,
+    field: 'user_id',
+  })
+  userId!: string;
+}
+
 // Export all junction tables
 export const JunctionTables = {
   CommunityInterest,
   UserInterest,
   BlogInterest,
+  PostTag,
+  ForumDiscussionTag,
 };


### PR DESCRIPTION
## Summary
- Add `PostTag` and `ForumDiscussionTag` junction table models for tagging users in posts and forum discussions
- Create separate migrations for each junction table (`post_tags`, `forum_discussion_tags`)
- Both tables use compound primary keys (entity ID + user ID) with CASCADE deletes and composite indexes

CLOSES : VWA84
