### PR TITLE
feat(posts): accept presign mediaKeys flow at POST /posts?upload=presign (VWA-123)

### DIFF
--- a/src/services/posts/lib/createFromMediaKeys.ts
+++ b/src/services/posts/lib/createFromMediaKeys.ts
@@ -1,0 +1,160 @@
+import { BadRequest, Forbidden, GeneralError } from '@feathersjs/errors';
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
+
+import { s3Client } from '../../../storage/s3';
+import { Application } from '../../../declarations';
+
+const PENDING_PREFIX = 'pending/';
+
+export type PostMediaType = 'image' | 'video' | 'audio';
+
+export interface PostMediaKeyInput {
+  key: string;
+  type?: PostMediaType;
+}
+
+export interface PresignPostBody {
+  postText?: string;
+  privacyType?: string;
+  communityId?: string;
+  mediaKeys?: PostMediaKeyInput[];
+}
+
+export interface ResolvedMedia {
+  key: string;
+  publicUrl: string;
+  contentType: string;
+  contentLength: number;
+}
+
+const validateBody = (data: unknown): PresignPostBody => {
+  if (!data || typeof data !== 'object') {
+    throw new BadRequest('Request body must be a JSON object');
+  }
+  const body = data as PresignPostBody;
+  if (body.mediaKeys != null && !Array.isArray(body.mediaKeys)) {
+    throw new BadRequest('mediaKeys must be an array');
+  }
+  if (body.postText != null && typeof body.postText !== 'string') {
+    throw new BadRequest('postText must be a string');
+  }
+  return body;
+};
+
+const validateKeyOwnership = (key: string, userId: string): void => {
+  if (typeof key !== 'string' || key.length === 0) {
+    throw new BadRequest('mediaKey.key must be a non-empty string');
+  }
+  if (!key.startsWith(PENDING_PREFIX)) {
+    throw new BadRequest(
+      `mediaKey.key must start with '${PENDING_PREFIX}': ${key}`,
+    );
+  }
+  // pending/{userId}/{uuid}.{ext}
+  const segments = key.slice(PENDING_PREFIX.length).split('/');
+  if (segments.length < 2) {
+    throw new BadRequest(`Malformed mediaKey: ${key}`);
+  }
+  const keyOwner = segments[0];
+  if (keyOwner !== String(userId)) {
+    throw new Forbidden(
+      `mediaKey ownership mismatch (key belongs to a different user)`,
+    );
+  }
+};
+
+const headObject = async (
+  bucket: string,
+  key: string,
+): Promise<{ contentType: string; contentLength: number }> => {
+  try {
+    const out = await s3Client.send(
+      new HeadObjectCommand({ Bucket: bucket, Key: key }),
+    );
+    return {
+      contentType: out.ContentType ?? 'application/octet-stream',
+      contentLength: typeof out.ContentLength === 'number' ? out.ContentLength : 0,
+    };
+  } catch (err: unknown) {
+    const status =
+      typeof err === 'object' && err !== null && '$metadata' in err
+        ? (err as { $metadata?: { httpStatusCode?: number } }).$metadata
+            ?.httpStatusCode
+        : undefined;
+    if (status === 404 || status === 403) {
+      throw new BadRequest(`Media not found in S3: ${key}`);
+    }
+    throw err;
+  }
+};
+
+export const resolveMediaKeys = async (
+  mediaKeys: PostMediaKeyInput[],
+  userId: string,
+  bucket: string,
+): Promise<ResolvedMedia[]> => {
+  if (!bucket) {
+    throw new GeneralError('S3_BUCKET_NAME is not configured');
+  }
+  return Promise.all(
+    mediaKeys.map(async (item) => {
+      validateKeyOwnership(item.key, userId);
+      const { contentType, contentLength } = await headObject(bucket, item.key);
+      const publicUrl = `https://${bucket}.s3.amazonaws.com/${item.key}`;
+      return { key: item.key, publicUrl, contentType, contentLength };
+    }),
+  );
+};
+
+const buildMediaRow = (resolved: ResolvedMedia, userId: string) => ({
+  // Until VWA-122 (media-processor Lambda) ships, all variant fields point
+  // at the same original URL. Lambda will rewrite these once variants exist.
+  original: resolved.publicUrl,
+  large: resolved.publicUrl,
+  medium: resolved.publicUrl,
+  small: resolved.publicUrl,
+  tiny: resolved.publicUrl,
+  UserId: userId,
+});
+
+export const createFromMediaKeys = async (
+  app: Application,
+  data: unknown,
+  params: { User?: { id: string }; user?: { id: string } } & Record<
+    string,
+    unknown
+  >,
+): Promise<unknown> => {
+  const body = validateBody(data);
+  const userId = params?.User?.id ?? params?.user?.id;
+  if (!userId) {
+    throw new Forbidden('Authenticated user required');
+  }
+
+  const bucket = process.env.S3_BUCKET_NAME || '';
+  const mediaKeys = body.mediaKeys ?? [];
+
+  const resolved =
+    mediaKeys.length > 0
+      ? await resolveMediaKeys(mediaKeys, String(userId), bucket)
+      : [];
+
+  const post = await app.service('posts').Model.create({
+    postText: body.postText ?? '',
+    privacyType: body.privacyType ?? 'public',
+    communityId: body.communityId,
+    userId,
+  });
+
+  if (resolved.length > 0) {
+    const mediaRows = resolved.map((r) => buildMediaRow(r, String(userId)));
+    // sequelize-typescript exposes `.models` at runtime; cast matches the
+    // existing codebase pattern (e.g. albums.class.ts, posts.class.ts).
+    const created = await (app.get('sequelizeClient') as any).models.Media.bulkCreate(
+      mediaRows,
+    );
+    await post.addMedia(created);
+  }
+
+  return app.service('posts').get(post.id, params);
+};

--- a/src/services/posts/posts.class.ts
+++ b/src/services/posts/posts.class.ts
@@ -2,6 +2,7 @@ import { Service, SequelizeServiceOptions } from 'feathers-sequelize';
 
 import common from '../../lib/utils/common';
 import { Application } from '../../declarations';
+import { createFromMediaKeys } from './lib/createFromMediaKeys';
 
 const { getUploadedFiles } = common;
 
@@ -15,12 +16,16 @@ export class Posts extends Service {
   }
 
   async create(data, params) {
+    if (params?.query?.upload === 'presign') {
+      return createFromMediaKeys(this.app, data, params);
+    }
+
     const postData = getUploadedFiles(['postImage', 'postVideo'], data);
-    
+
     console.log('data', data);
     console.log('postData', postData);
     const { Media: mediaData } = postData;
-    
+
     // Create the post first
     const post = await this.app
       .service('posts')
@@ -30,7 +35,7 @@ export class Posts extends Service {
       const mediaRecords = await this.app
         .get('sequelizeClient')
         .models.Media.bulkCreate(mediaData);
-      
+
       await post.addMedia(mediaRecords);
     }
 


### PR DESCRIPTION
## Summary

Adds a parallel post-create code path that takes JSON `{ postText, privacyType, communityId?, mediaKeys[] }` instead of multipart bytes. Selected by the `?upload=presign` query param so the existing multipart path stays the default. This closes the loop for the new mobile flow ([VWA-125](https://linear.app/vwanu/issue/VWA-125) — PR [#152](https://github.com/Vwanu/vwanu-mobile-application/pull/152) on the mobile repo).

[VWA-123](https://linear.app/vwanu/issue/VWA-123) · stacks on [#XXX (VWA-119)](https://github.com/Vwanu/vwanu-api/pulls) · parent [VWA-88](https://linear.app/vwanu/issue/VWA-88)

## Behavior

| Request | Path taken |
|---|---|
| `POST /posts` (no query, multipart) | Existing flow — unchanged |
| `POST /posts?upload=presign` (JSON `mediaKeys`) | New `createFromMediaKeys` helper |

## What's new

- **`src/services/posts/lib/createFromMediaKeys.ts`** — the new flow:
  1. Validate body shape.
  2. For each `mediaKey.key`: confirm it starts with `pending/{requesterUserId}/...` (rejects keys belonging to other users → 403).
  3. `HeadObject` in S3 to confirm the file exists; capture real mime/size (404/403 → 400 "media not found").
  4. Build Media rows with `original = publicUrl` (and same URL for all variant fields — Lambda will rewrite once VWA-122 ships).
  5. `Post.create` + `Media.bulkCreate` + `post.addMedia` + return enriched post.
- **`src/services/posts/posts.class.ts`** — branches on `params.query.upload === 'presign'` and delegates. Multipart path is untouched.

## Verified end-to-end

Smoke-tested against `localhost:3000` after this change:

| Probe | Result |
|---|---|
| Presign → PUT to S3 → `POST /posts?upload=presign` w/ valid key | **201**, post created, media associated |
| `mediaKeys[0].key` belongs to a different user | **403** "ownership mismatch" |
| `mediaKeys[0].key` doesn't exist in S3 | **400** "Media not found in S3: ..." |
| `POST /posts` with no query (multipart) | unchanged — works as before |

## Out of scope (deferred until VWA-122 lands)

- **DynamoDB MediaStatus read** — table doesn't exist yet.
- **`moderationState` column + migration** — nothing produces the value yet, so adding the column would just mean defaulting everything to `pending`.
- **Soft-gate enforcement at feed query** — same reason; will be added when there's actual moderation data to gate on.
- **Variant URL rewriting** — Lambda's job in VWA-122. For now, all variant fields (`large/medium/small/tiny`) point at the same `original` URL, which renders fine.

## Notes

- Targets `wadprog/vwa-119-…` (stacked PR). Will auto-rebase to `qa/cycle-22` when VWA-119 merges.
- ECS task role already has `s3:GetObject` from `MediaBucket.yml`'s policy — `HeadObject` uses the same permission, no IAM change required.