### PR TITLE
feat(s3): auto-delete pending/ uploads after 24h (VWA-120)

### DIFF
--- a/resources/s3/MediaBucket.yml
+++ b/resources/s3/MediaBucket.yml
@@ -53,6 +53,16 @@ Resources:
             # Delete old versions after 90 days
             NoncurrentVersionExpiration:
               NoncurrentDays: 90
+          # Auto-delete direct-uploads that were never linked to a post.
+          # Mobile uploads via presigned URL land under pending/{userId}/{uuid}.{ext};
+          # the media-processor Lambda promotes accepted files to media/. Anything
+          # left in pending/ is an orphan (user closed the app mid-flow).
+          # 1 day is the S3 minimum; effectively a ~24h cleanup pass.
+          - Id: DeletePendingUploads
+            Status: Enabled
+            Filter:
+              Prefix: pending/
+            ExpirationInDays: 1
       # Tags for organization
       Tags:
         - Key: Name

--- a/resources/s3/MediaBucket.yml
+++ b/resources/s3/MediaBucket.yml
@@ -57,12 +57,16 @@ Resources:
           # Mobile uploads via presigned URL land under pending/{userId}/{uuid}.{ext};
           # the media-processor Lambda promotes accepted files to media/. Anything
           # left in pending/ is an orphan (user closed the app mid-flow).
-          # 1 day is the S3 minimum; effectively a ~24h cleanup pass.
+          # In a versioned bucket, ExpirationInDays adds a delete marker; pair it
+          # with NoncurrentVersionExpiration so the orphaned object's data is also
+          # removed after roughly the same 1-day lifecycle window.
           - Id: DeletePendingUploads
             Status: Enabled
             Filter:
               Prefix: pending/
             ExpirationInDays: 1
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
       # Tags for organization
       Tags:
         - Key: Name


### PR DESCRIPTION
## Summary

Adds a third S3 lifecycle rule on `VwanuMediaBucket` so uploads that land under `pending/{userId}/{uuid}.{ext}` via the presigned-URL flow but never get linked to a post (user closes the app mid-flow, post-create never fires, etc.) get garbage-collected the next lifecycle pass instead of accumulating in S3 forever.

[VWA-120](https://linear.app/vwanu/issue/VWA-120) · parent [VWA-88](https://linear.app/vwanu/issue/VWA-88)

## Diff

`resources/s3/MediaBucket.yml` — one rule appended:

```yaml
- Id: DeletePendingUploads
  Status: Enabled
  Filter:
    Prefix: pending/
  ExpirationInDays: 1
```

`1` is the S3 minimum for lifecycle expiration — effectively a ~24h cleanup pass. Existing rules (`DeleteIncompleteMultipartUploads` 7d, `TransitionOldVersions` 30d→IA / 90d→delete) untouched.

## Why

VWA-119 (presign endpoint) and VWA-123 (post-create with `mediaKeys`) put new files under `pending/...`. Without this rule, every "user picks a photo, never posts" flow leaves a permanent file in S3.

## Test plan post-deploy

- [ ] `aws s3 cp tiny.jpg s3://dev-vwanu-uploads/pending/test/foo.jpg`
- [ ] Wait for next lifecycle pass (~24-48h) → file gone
- [ ] Existing flows still work (multipart upload paths unaffected)

## Independent of the data-flow stack

Branched off `qa/cycle-21` directly (not stacked on VWA-119/123) — pure CFN edit, no code dependency on those PRs. Can merge on its own timeline.

## Out of scope

- Tightening `AllowedOrigins: '*'` in CORS to actual mobile/web origins. Production hardening, but not blocking; tracked as a follow-up.
- Lifecycle on `media/` (the post-processing prefix) — those files are linked to posts and should NOT be auto-deleted.