### PR TITLE
VWA-131:Deploy AWS Dynamic Image Transformation as nested CFN

### DIFF
--- a/resources/cloudfront/ImageHandler.yml
+++ b/resources/cloudfront/ImageHandler.yml
@@ -49,15 +49,11 @@ Resources:
         EnableS3ObjectLambdaParameter: 'No'
         # Fresh distribution; not piggybacking on an existing one.
         UseExistingCloudFrontDistributionParameter: 'No'
-      Tags:
-        - Key: Name
-          Value: ${self:service}-${self:provider.stage}-image-handler
-        - Key: Service
-          Value: ${self:service}
-        - Key: Stage
-          Value: ${self:provider.stage}
-        - Key: Purpose
-          Value: cloudfront-image-transforms
+      # Note: NO Tags block here — the AWS solution template applies its own
+      # tags to nested resources (notably IAM roles), and IAM treats tag keys
+      # as case-insensitive. Adding our own tags here was causing IAM role
+      # creation to fail with "Duplicate tag keys found". Nested-stack
+      # resources inherit propagating tags from the parent stack anyway.
 
 Outputs:
   CloudFrontDomain:

--- a/resources/cloudfront/ImageHandler.yml
+++ b/resources/cloudfront/ImageHandler.yml
@@ -56,8 +56,8 @@ Resources:
       # resources inherit propagating tags from the parent stack anyway.
 
 Outputs:
-  CloudFrontDomain:
-    Description: Edge URL for media transforms (set as EXPO_PUBLIC_CDN_URL on mobile)
-    Value: !GetAtt ImageHandlerStack.Outputs.CloudFrontDomainName
+  ImageHandlerApiEndpoint:
+    Description: Full CloudFront URL for image transforms (set as EXPO_PUBLIC_CDN_URL on mobile)
+    Value: !GetAtt ImageHandlerStack.Outputs.ApiEndpoint
     Export:
-      Name: ${self:service}-${self:provider.stage}-CloudFrontDomain
+      Name: ${self:service}-${self:provider.stage}-ImageHandlerApiEndpoint

--- a/resources/cloudfront/ImageHandler.yml
+++ b/resources/cloudfront/ImageHandler.yml
@@ -1,0 +1,67 @@
+# AWS-published "Dynamic Image Transformation for Amazon CloudFront" solution
+# deployed as a nested CloudFormation stack inside the API stack.
+#
+# What it provides:
+#   - CloudFront distribution sitting in front of VwanuMediaBucket
+#   - Lambda@Edge that transforms images on demand based on the request URL
+#   - Edge cache so subsequent requests for the same transform are served fast
+#
+# Mobile builds image URLs as:
+#   https://<CloudFrontDomain>/<base64(JSON)>
+# where the JSON looks like:
+#   { "bucket": "<bucket>", "key": "posts/.../foo.jpg", "edits": { "resize": { "width": 400, "fit": "cover" } } }
+#
+# Solution version is PINNED to v7.0.1 deliberately — bumping should be a
+# conscious change. AWS publishes new versions at the same URL pattern with
+# different version segments. Source: https://docs.aws.amazon.com/solutions/dynamic-image-transformation-for-amazon-cloudfront/
+#
+# Lambda@Edge requires the parent stack to be deployed in us-east-1. ✓ (provider.region)
+Resources:
+  ImageHandlerStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://solutions-reference.s3.us-east-1.amazonaws.com/dynamic-image-transformation-for-amazon-cloudfront/v7.0.1/dynamic-image-transformation-for-amazon-cloudfront.template
+      TimeoutInMinutes: 30
+      Parameters:
+        # Reference our existing media bucket. !Ref returns the bucket name,
+        # which is what SourceBucketsParameter expects (comma-separated names).
+        SourceBucketsParameter: !Ref VwanuMediaBucket
+        # Skip the AWS demo UI — we don't need it in our account.
+        DeployDemoUIParameter: 'No'
+        # 30d log retention (default 180d is wasteful for our scale).
+        LogRetentionPeriodParameter: 30
+        # Auto-serve WebP when the client sends Accept: image/webp.
+        # Significant bandwidth win for modern mobile clients.
+        AutoWebPParameter: 'Yes'
+        # Enable CORS so the mobile app can fetch from the edge.
+        CorsEnabledParameter: 'Yes'
+        # Wildcard for now; tighten in a future production-hardening ticket.
+        CorsOriginParameter: '*'
+        # Signed URLs deferred — no SecretsManager dependency for now.
+        EnableSignatureParameter: 'No'
+        # No fallback image yet; broken-image is acceptable.
+        EnableDefaultFallbackImageParameter: 'No'
+        # All edge locations. Drop to PriceClass_100 (US/CA/EU only) for cost.
+        CloudFrontPriceClassParameter: PriceClass_All
+        # Origin Shield off — cost optimization for later.
+        OriginShieldRegionParameter: Disabled
+        # We don't hit Lambda's response-size limit; default backend is fine.
+        EnableS3ObjectLambdaParameter: 'No'
+        # Fresh distribution; not piggybacking on an existing one.
+        UseExistingCloudFrontDistributionParameter: 'No'
+      Tags:
+        - Key: Name
+          Value: ${self:service}-${self:provider.stage}-image-handler
+        - Key: Service
+          Value: ${self:service}
+        - Key: Stage
+          Value: ${self:provider.stage}
+        - Key: Purpose
+          Value: cloudfront-image-transforms
+
+Outputs:
+  CloudFrontDomain:
+    Description: Edge URL for media transforms (set as EXPO_PUBLIC_CDN_URL on mobile)
+    Value: !GetAtt ImageHandlerStack.Outputs.CloudFrontDomainName
+    Export:
+      Name: ${self:service}-${self:provider.stage}-CloudFrontDomain

--- a/serverless.yml
+++ b/serverless.yml
@@ -143,6 +143,9 @@ resources:
   # S3 Media Storage
   - ${file(resources/s3/MediaBucket.yml)}
 
+  # CloudFront image handler (AWS Dynamic Image Transformation solution, nested CFN)
+  - ${file(resources/cloudfront/ImageHandler.yml)}
+
   # ECS
   - ${file(resources/ecs/ecs.yml)}
 


### PR DESCRIPTION
## Summary

Deploys the AWS-published [Dynamic Image Transformation for Amazon CloudFront](https://docs.aws.amazon.com/solutions/dynamic-image-transformation-for-amazon-cloudfront/) solution (v7.0.1) as a nested CloudFormation stack inside `vwanu-api/serverless.yml`. Replaces the cancelled VWA-121/122 (custom SQS + Lambda + Sharp pipeline) with on-demand transforms via CloudFront + Lambda@Edge.

[VWA-131](https://linear.app/vwanu/issue/VWA-131) · parent [VWA-88](https://linear.app/vwanu/issue/VWA-88)

## What changed

- **New `resources/cloudfront/ImageHandler.yml`** — `AWS::CloudFormation::Stack` referencing the AWS-hosted v7.0.1 template. `SourceBucketsParameter` references `VwanuMediaBucket` directly. CloudFront domain is exported via `${service}-${stage}-CloudFrontDomain`.
- **`serverless.yml`** — registers the new resource file.

## Parameter choices

| Parameter | Value | Why |
|---|---|---|
| `SourceBucketsParameter` | `!Ref VwanuMediaBucket` | The existing media bucket |
| `DeployDemoUIParameter` | `No` | Don't ship the AWS demo UI to our account |
| `LogRetentionPeriodParameter` | `30` | Cost; default `180` is excessive at our scale |
| `AutoWebPParameter` | `Yes` | Significant bandwidth win on modern clients |
| `CorsEnabledParameter` | `Yes` | Mobile fetches need CORS |
| `CorsOriginParameter` | `*` | Tighten in production hardening later |
| `EnableSignatureParameter` | `No` | Defer; no SecretsManager dependency for now |
| `CloudFrontPriceClassParameter` | `PriceClass_All` | Default; downsize to `PriceClass_100` later for cost |
| `EnableSignature` / `EnableDefaultFallbackImage` / `OriginShield` / `EnableS3ObjectLambda` / `UseExistingCloudFrontDistribution` | `No`/`Disabled` | All deferred / not needed |

## What this PR does NOT do

- Mobile-side URL helper → VWA-132 (separate ticket).
- Migrating the DB to store key-not-URL → VWA-133.
- Setting `EXPO_PUBLIC_CDN_URL` on mobile builds — that's a small follow-up after first deploy reveals the actual CloudFront domain.

## Verification

- YAML parses cleanly.
- Template URL reachable (HTTP 200 on v7.0.1).
- Real test = `sls deploy --stage dev` succeeds, then visit `https://<cloudfront-domain>/<base64(JSON)>` and see the transformed image.

## Risks + mitigation

| Risk | Mitigation |
|---|---|
| First nested-stack deploy in this serverless setup; deploy role IAM may have gaps | Test in dev first; surface any IAM perm gap and add what's needed |
| Lambda@Edge requires us-east-1 deploy | Already there ✓ |
| Initial CloudFront propagation is slow (5-15 min); `sls deploy` blocks | One-time cost on first deploy |
| AWS template change between version bumps could break us | We pin to `v7.0.1`; bumping is a deliberate edit |

## Out of scope

- Cost/security hardening (signed URLs, tighter CORS, lower price class) — separate future ticket if/when needed.