### PR TITLE
VWA-127:Replace users multipart upload with presign-key flow (BE)

### DIFF
--- a/src/Hooks/ApplyProfileMediaKeys.hooks.ts
+++ b/src/Hooks/ApplyProfileMediaKeys.hooks.ts
@@ -1,0 +1,108 @@
+import { HookContext } from '@feathersjs/feathers';
+import { BadRequest, GeneralError } from '@feathersjs/errors';
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
+
+import { s3Client } from '../storage/s3';
+
+const ALLOWED_KEY_PREFIXES = [
+  'posts/',
+  'profiles/',
+  'messages/',
+  'blog/',
+  'community/',
+];
+
+const validateKeyShape = (key: string, field: string): void => {
+  if (typeof key !== 'string' || key.length === 0) {
+    throw new BadRequest(`${field} must be a non-empty string`);
+  }
+  if (key.includes('..') || key.startsWith('/')) {
+    throw new BadRequest(`Malformed ${field}: ${key}`);
+  }
+  if (!ALLOWED_KEY_PREFIXES.some((p) => key.startsWith(p))) {
+    throw new BadRequest(
+      `${field} must start with one of: ${ALLOWED_KEY_PREFIXES.join(', ')}`,
+    );
+  }
+};
+
+const headObject = async (bucket: string, key: string): Promise<void> => {
+  try {
+    await s3Client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+  } catch (err: unknown) {
+    const status =
+      typeof err === 'object' && err !== null && '$metadata' in err
+        ? (err as { $metadata?: { httpStatusCode?: number } }).$metadata
+            ?.httpStatusCode
+        : undefined;
+    if (status === 404 || status === 403) {
+      throw new BadRequest(`Media not found in S3: ${key}`);
+    }
+    throw err;
+  }
+};
+
+const publicUrlFor = (bucket: string, key: string): string =>
+  `https://${bucket}.s3.amazonaws.com/${key}`;
+
+/**
+ * Before-hook for the users service. When a patch body contains
+ * `profilePictureKey` or `coverPictureKey`, validates each key (allowed
+ * prefix, file exists in S3) and rewrites the body to set the matching
+ * URL column instead.
+ *
+ * If neither key is present, no-op (other patches like name/email
+ * updates pass through untouched).
+ *
+ * Also defensively strips any client-supplied `profilePicture` /
+ * `coverPicture` URL fields — these can only be set via the key flow
+ * to prevent old/buggy clients from writing arbitrary strings (e.g.
+ * local file URIs) into the DB.
+ */
+const applyProfileMediaKeys = async (
+  context: HookContext,
+): Promise<HookContext> => {
+  const data = context.data ?? {};
+  const bucket = process.env.S3_BUCKET_NAME || '';
+
+  const fieldMap: Array<[string, string]> = [
+    ['profilePictureKey', 'profilePicture'],
+    ['coverPictureKey', 'coverPicture'],
+  ];
+
+  const writes: Record<string, string> = {};
+  for (const [keyField, urlField] of fieldMap) {
+    const key = data[keyField];
+    if (key === undefined || key === null) continue;
+    if (!bucket) {
+      throw new GeneralError('S3_BUCKET_NAME is not configured');
+    }
+    validateKeyShape(key, keyField);
+    await headObject(bucket, key);
+    writes[urlField] = publicUrlFor(bucket, key);
+    delete data[keyField];
+  }
+
+  // Reject local file URIs sent directly in profilePicture/coverPicture.
+  // External http(s) URLs (e.g. UI-Avatars defaults) and null clears
+  // remain allowed for backwards compat. Real S3-hosted images can only
+  // be set via the *Key flow above.
+  if (context.params?.provider) {
+    for (const field of ['profilePicture', 'coverPicture']) {
+      const value = data[field];
+      if (
+        typeof value === 'string' &&
+        value.length > 0 &&
+        !/^https?:\/\//i.test(value)
+      ) {
+        delete data[field];
+      }
+    }
+  }
+
+  Object.assign(data, writes);
+  context.data = data;
+  return context;
+};
+
+export default applyProfileMediaKeys;

--- a/src/Hooks/ApplyProfileMediaKeys.hooks.ts
+++ b/src/Hooks/ApplyProfileMediaKeys.hooks.ts
@@ -42,14 +42,11 @@ const headObject = async (bucket: string, key: string): Promise<void> => {
   }
 };
 
-const publicUrlFor = (bucket: string, key: string): string =>
-  `https://${bucket}.s3.amazonaws.com/${key}`;
-
 /**
  * Before-hook for the users service. When a patch body contains
  * `profilePictureKey` or `coverPictureKey`, validates each key (allowed
- * prefix, file exists in S3) and rewrites the body to set the matching
- * URL column instead.
+ * prefix, file exists in S3) and rewrites the body to write the bare key
+ * to the matching column. Mobile renders via cdnImageUrl(key, preset).
  *
  * If neither key is present, no-op (other patches like name/email
  * updates pass through untouched).
@@ -79,7 +76,9 @@ const applyProfileMediaKeys = async (
     }
     validateKeyShape(key, keyField);
     await headObject(bucket, key);
-    writes[urlField] = publicUrlFor(bucket, key);
+    // VWA-133: store the bare S3 key in the DB column (not the full URL).
+    // Mobile builds the rendered URL via cdnImageUrl(key, preset).
+    writes[urlField] = key;
     delete data[keyField];
   }
 

--- a/src/services/users/users.hooks.ts
+++ b/src/services/users/users.hooks.ts
@@ -4,7 +4,7 @@ import { HookContext } from '@feathersjs/feathers';
 
 import isSelf from '../../Hooks/isSelf.hook';
 import updateTsVector from './hook/updateTsVector';
-import saveProfilePicture from '../../Hooks/SaveProfilePictures.hooks';
+import applyProfileMediaKeys from '../../Hooks/ApplyProfileMediaKeys.hooks';
 import includeFriendshipStatus from './hook/includeFriendshipStatus';
 
 const { protect } = local.hooks;
@@ -36,7 +36,7 @@ const hooks = {
       commonHooks.isProvider('external'),
       commonHooks.preventChanges(true, ...['email']),
       ),
-      saveProfilePicture(['profilePicture', 'coverPicture']),
+      applyProfileMediaKeys,
     ],
     remove: [isSelf],
   },

--- a/src/services/users/users.service.ts
+++ b/src/services/users/users.service.ts
@@ -4,8 +4,6 @@ import hooks from './users.hooks';
 import { Users } from './users.class';
 import { User } from '../../database/user';
 import { Application } from '../../declarations';
-import { profileStorage } from '../../storage/s3';
-import fileToFeathers from '../../middleware/PassFilesToFeathers/file-to-feathers.middleware';
 
 declare module '../../declarations' {
   // eslint-disable-next-line no-unused-vars
@@ -23,17 +21,10 @@ export default function (app: Application): void {
     },
   };
 
-
-  // Initialize our service with any options it requires
-  app.use(
-    '/users',
-    profileStorage.fields([
-      { name: 'profilePicture', maxCount: 1 },
-      { name: 'coverPicture', maxCount: 1 },
-    ]),
-    fileToFeathers,
-    new Users(options, app),
-  );
+  // Direct registration — no multer/multipart middleware. Profile/cover
+  // pictures land via the presign flow handled by applyProfileMediaKeys
+  // in users.hooks.ts (clients PATCH with profilePictureKey/coverPictureKey).
+  app.use('/users', new Users(options, app));
   const service = app.service('users');
   service.hooks(hooks);
 }


### PR DESCRIPTION
## Summary

Removes multipart-upload handling from the users service. Profile/cover pictures now arrive as `profilePictureKey` / `coverPictureKey` from the mobile presign flow; the new `applyProfileMediaKeys` before-hook validates the key, calls HeadObject to confirm the file exists, and resolves it to the public URL written to the existing `profilePicture` / `coverPicture` columns.

[VWA-127](https://linear.app/vwanu/issue/VWA-127) · stacks on [#63 (VWA-130 BE)](https://github.com/Vwanu/vwanu-api/pull/63) · parent [VWA-88](https://linear.app/vwanu/issue/VWA-88)

Mobile companion: PR opening shortly on the mobile repo.

## Why no flag/branch on `?upload=presign`

Unlike the posts service (which keeps multipart for backward compat under VWA-123), the users service had only one upload-using surface, and the existing JSON-fallback flow was already broken (clients were sending local `file://` URIs that ended up persisted as `profilePicture` strings). With nothing legitimate to preserve, this PR rips out the multipart path entirely.

## What changed

- **`src/services/users/users.service.ts`** — drop `profileStorage.fields(...)` multer middleware and `fileToFeathers` middleware. Plain `app.use('/users', new Users(options, app))`.
- **`src/services/users/users.hooks.ts`** — replace `saveProfilePicture(['profilePicture', 'coverPicture'])` (multer-driven) with `applyProfileMediaKeys` (presign-key driven).
- **`src/Hooks/ApplyProfileMediaKeys.hooks.ts`** — NEW. For each provided `*Key` field: validate prefix (`posts/`, `profiles/`, `messages/`, `blog/`, `community/`), HeadObject to confirm file exists, write the resolved public URL into the matching column. Defensively rejects local file URIs sent directly in `profilePicture` / `coverPicture` (allows external http(s) URLs through for backwards compat with UI-Avatars defaults from registration).

## Smoke test plan post-merge

- Patch `/users/{id}` with `{ profilePictureKey: 'profiles/pictures/2026/05/<uuid>.jpg', firstName: 'X' }` → `profilePicture` updates to the public URL, `firstName` updates too.
- Patch with an arbitrary key like `random/etc.jpg` → 400 "must start with one of: ...".
- Patch with a key that doesn't exist in S3 → 400 "Media not found in S3".
- Patch with `{ profilePicture: 'file:///local/uri.jpg' }` (old broken client) → field stripped, no DB write.
- Patch with `{ profilePicture: 'https://ui-avatars.com/...' }` (skip default) → still works.
- Patch with `{ firstName: 'X' }` only → unchanged behavior.

## Out of scope

- `SaveProfilePictures.hooks.ts` is left in place — may still be used by other surfaces. Cleanup ticket VWA-126 will sweep.
- Other multipart-using services (communities, blogs) → VWA-128, VWA-129.