### PR TITLE
VWA-133:Store S3 key in DB instead of full URL (BE)

### DIFF
--- a/migrations/20260504050000-store-media-keys.js
+++ b/migrations/20260504050000-store-media-keys.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * VWA-133 — switch picture columns from full S3 URLs to S3 keys.
+ *
+ * For rows where the column holds a `*.amazonaws.com/<key>` URL, extract
+ * just the key. Rows holding external URLs (UI-Avatars, Cloudinary,
+ * Unsplash) are left untouched — mobile's cdnImageUrl helper passes those
+ * through.
+ *
+ * Also drops `medias.large/medium/small/tiny` — these were Cloudinary-era
+ * derived URLs. Variants are now generated on-demand at the CloudFront
+ * edge by the AWS image-handler stack (VWA-131).
+ *
+ * Skips `users.cover_picture` — that column is being dropped entirely
+ * under VWA-137.
+ */
+
+const EXTRACT = `regexp_replace($COL$, '^https?://[^/]*\\.amazonaws\\.com/(.*)$', '\\1')`;
+const PREDICATE = `$COL$ LIKE '%amazonaws.com/%'`;
+
+const buildBackfill = (table, column) => `
+  UPDATE ${table}
+  SET ${column} = ${EXTRACT.replaceAll('$COL$', column)}
+  WHERE ${PREDICATE.replaceAll('$COL$', column)}
+`;
+
+module.exports = {
+  async up(queryInterface) {
+    // Backfill: extract key from S3 URLs across every picture column.
+    const backfills = [
+      ['medias', 'original'],
+      ['users', 'profile_picture'],
+      ['communities', 'profile_picture'],
+      ['communities', 'cover_picture'],
+      ['blogs', 'title_picture'],
+    ];
+    for (const [table, column] of backfills) {
+      await queryInterface.sequelize.query(buildBackfill(table, column));
+    }
+
+    // Drop the obsolete derived-variant columns on medias.
+    for (const col of ['large', 'medium', 'small', 'tiny']) {
+      await queryInterface.removeColumn('medias', col);
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Re-add the dropped columns (nullable). Variant data is lost; the
+    // BeforeSave hook in older code would have re-derived them on the
+    // next save.
+    for (const col of ['large', 'medium', 'small', 'tiny']) {
+      await queryInterface.addColumn('medias', col, {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
+
+    // Best-effort: re-prepend the bucket prefix to any value that looks
+    // like a key. Reads bucket name from env at down-migration time.
+    const bucket = process.env.S3_BUCKET_NAME;
+    if (!bucket) {
+      // Without a bucket, leave keys as-is — rows still read; cdnImageUrl
+      // on the mobile side handles either form.
+      return;
+    }
+    const region = process.env.AWS_REGION || 'us-east-1';
+    const prefix = `https://${bucket}.s3.${region}.amazonaws.com/`;
+    const restore = (table, column) => `
+      UPDATE ${table}
+      SET ${column} = '${prefix}' || ${column}
+      WHERE ${column} IS NOT NULL
+        AND ${column} NOT LIKE 'http%'
+    `;
+    const restorations = [
+      ['medias', 'original'],
+      ['users', 'profile_picture'],
+      ['communities', 'profile_picture'],
+      ['communities', 'cover_picture'],
+      ['blogs', 'title_picture'],
+    ];
+    for (const [table, column] of restorations) {
+      await queryInterface.sequelize.query(restore(table, column));
+    }
+  },
+};

--- a/src/database/media.ts
+++ b/src/database/media.ts
@@ -1,21 +1,27 @@
-import { Table, Column, Model, DataType, BeforeSave, BelongsTo , ForeignKey, BelongsToMany, TableOptions} from 'sequelize-typescript';
-import config from 'config';
+import {
+  Table,
+  Column,
+  Model,
+  DataType,
+  BelongsTo,
+  ForeignKey,
+  BelongsToMany,
+  TableOptions,
+} from 'sequelize-typescript';
 import { User } from './user';
 import { Post } from './post';
-// import { Post } from './post';
-// import { Album } from './album';
-
-const tinySize = config.get('tinySize');
-const smallSize = config.get('smallSize');
-const mediumSize = config.get('mediumSize');
 
 export interface MediaInterface {
   id: number;
+  /**
+   * S3 key (e.g. `posts/2026/05/03/<uuid>.jpg`) for media stored in our
+   * own bucket, or a passthrough external URL (e.g. UI-Avatars defaults,
+   * legacy Cloudinary URLs). Mobile's cdnImageUrl helper handles both.
+   *
+   * Variant URLs (large/medium/small/tiny) are no longer stored — the
+   * CloudFront image-handler stack (VWA-131) generates them on demand.
+   */
   original: string;
-  large: string;
-  medium: string;
-  small: string;
-  tiny: string;
   UserId: string;
 }
 
@@ -38,57 +44,14 @@ export class Media extends Model<MediaInterface> implements MediaInterface {
   })
   original!: string;
 
-  @Column({
-    type: DataType.STRING,
-    allowNull: true,
-  })
-  medium!: string;
-
-  @Column({
-    type: DataType.STRING,
-    allowNull: true,
-  })
-  large!: string;
-
-  @Column({
-    type: DataType.STRING,
-    allowNull: true,
-  })
-  small!: string;
-
-  @Column({
-    type: DataType.STRING,
-    allowNull: true,
-  })
-  tiny!: string;
-
   @ForeignKey(() => User)
   @Column({
     type: DataType.UUID,
     allowNull: false,
-    field: 'user_id', // Use snake_case to match migration
+    field: 'user_id',
   })
   UserId!: string;
 
-  @BeforeSave
-  static generateImageSizes(instance: Media) {
-    const { tiny, small, medium, original } = instance;
-
-    instance.medium =
-      medium !== undefined
-        ? medium
-        : original.replace(/upload\//g, `upload/${mediumSize}/`);
-    instance.small =
-      small !== undefined
-        ? small
-        : original.replace(/upload\//g, `upload/${smallSize}/`);
-    instance.tiny =
-      tiny !== undefined
-        ? tiny
-        : original.replace(/upload\//g, `upload/${tinySize}/`);
-  }
-
-  // TODO: Add associations with decorators when other models are converted
   @BelongsTo(() => User)
   User!: User;
 
@@ -98,11 +61,4 @@ export class Media extends Model<MediaInterface> implements MediaInterface {
     otherKey: 'post_id',
   })
   posts!: Post[];
-
-  // @BelongsToMany(() => Album, {
-  //   through: 'album_Media', // String-based junction table
-  //   foreignKey: 'media_id',
-  //   otherKey: 'album_id',
-  // })
-  // albums!: Album[];
 }

--- a/src/services/posts/lib/createFromMediaKeys.ts
+++ b/src/services/posts/lib/createFromMediaKeys.ts
@@ -22,7 +22,6 @@ export interface PresignPostBody {
 
 export interface ResolvedMedia {
   key: string;
-  publicUrl: string;
   contentType: string;
   contentLength: number;
 }
@@ -100,20 +99,16 @@ export const resolveMediaKeys = async (
     mediaKeys.map(async (item) => {
       validateKeyOwnership(item.key, userId);
       const { contentType, contentLength } = await headObject(bucket, item.key);
-      const publicUrl = `https://${bucket}.s3.amazonaws.com/${item.key}`;
-      return { key: item.key, publicUrl, contentType, contentLength };
+      return { key: item.key, contentType, contentLength };
     }),
   );
 };
 
 const buildMediaRow = (resolved: ResolvedMedia, userId: string) => ({
-  // Until VWA-122 (media-processor Lambda) ships, all variant fields point
-  // at the same original URL. Lambda will rewrite these once variants exist.
-  original: resolved.publicUrl,
-  large: resolved.publicUrl,
-  medium: resolved.publicUrl,
-  small: resolved.publicUrl,
-  tiny: resolved.publicUrl,
+  // VWA-133: store the S3 key, not the full URL. CDN-side variants are
+  // generated on demand by the AWS image-handler stack (VWA-131); mobile
+  // builds the rendered URL via cdnImageUrl(key, preset).
+  original: resolved.key,
   UserId: userId,
 });
 


### PR DESCRIPTION
## Summary

Switches every picture column in the DB from full S3 URL to S3 key. Mobile builds the rendered URL on demand via `cdnImageUrl(key, preset)` (VWA-132). Drops the `medias.large/medium/small/tiny` columns — variants are now generated at the CloudFront edge by the AWS image-handler stack (VWA-131).

[VWA-133](https://linear.app/vwanu/issue/VWA-133) · parent [VWA-88](https://linear.app/vwanu/issue/VWA-88)

Mobile companion: PR opening on `vwanu-mobile-application` next.

## What changed

- **`migrations/20260504050000-store-media-keys.js`** (new):
  - `UPDATE` on each picture column extracts the key from `*.amazonaws.com/<key>` URLs via `regexp_replace`.
  - Rows holding non-S3 URLs (UI-Avatars defaults, Cloudinary URLs, Unsplash test data) are left untouched — `cdnImageUrl` passes those through unchanged.
  - `removeColumn` on `medias.large/medium/small/tiny`.
  - Skips `users.cover_picture` — that column is being dropped entirely under [VWA-137](https://linear.app/vwanu/issue/VWA-137).
  - `down`: re-adds the variant columns (nullable, no data) and best-effort re-prepends the bucket prefix to keys.
- **`src/database/media.ts`**: drop `large/medium/small/tiny` columns + the Cloudinary-string-replace `BeforeSave generateImageSizes` hook + the `MediaInterface` variant fields.
- **`src/services/posts/lib/createFromMediaKeys.ts`**: `buildMediaRow` now writes `original: resolved.key` (was: `original: resolved.publicUrl` plus four duplicate variant fields). `ResolvedMedia.publicUrl` removed — no longer computed.

## Coordination with VWA-127

VWA-127's `applyProfileMediaKeys` hook currently writes `profilePicture: <publicUrl>`. When VWA-127 (#65) and this PR both land, that hook needs a one-line tweak: `writes[urlField] = key` (drop the `publicUrlFor()` call). Easy follow-up — either I push to #65 before merge or open a tiny adjustment PR after.

## Migration safety

- **Dev only** — no prod/staging exists yet, so atomic schema change is fine.
- Mobile reads `media.original` and feeds to `cdnImageUrl()` which already handles either a key OR an S3 URL. Mobile and backend can ship in either order.
- Down-migration re-adds columns; key→URL recovery is best-effort using the current `S3_BUCKET_NAME` env.

## Test plan

- [ ] `sequelize db:migrate` runs cleanly on dev DB.
- [ ] Existing post media still renders in the app (cdnImageUrl handles the key form).
- [ ] Existing UI-Avatars profile pictures still render (passthrough).
- [ ] New post created via presign flow stores a bare key in `medias.original` (verify via DB query).
- [ ] `medias.large/medium/small/tiny` columns gone (`\d medias` in psql).

## Out of scope

- VWA-127's hook URL→key adjustment — see "Coordination" above.
- `users.coverPicture` removal — VWA-137.
- `getS3KeyFromUrl` / `generateS3Url` legacy helpers in `s3.ts` — still used by `SaveProfilePictures.hooks.ts`. Cleanup ticket VWA-126 will sweep.