### PR TITLE
VWA-128:Replace communities multipart upload with presign-key flow (BE)

### DIFF
--- a/src/services/communities/communities.hooks.ts
+++ b/src/services/communities/communities.hooks.ts
@@ -6,9 +6,7 @@ import LimitToOwner from '../../Hooks/LimitToOwner';
 import { AutoOwn } from '../../Hooks';
 
 
-import saveProfilePicture from '../../Hooks/SaveProfilePictures.hooks';
-
-// import filesToBody from '../../middleware/PassFilesToFeathers/feathers-to-data.middleware';
+import applyProfileMediaKeys from '../../Hooks/ApplyProfileMediaKeys.hooks';
 
 // import SaveAndAttachInterests from '../../Hooks/SaveAndAttachInterest';
 
@@ -20,13 +18,12 @@ export default {
     find: [FindCommunities],
     create: [
       AutoOwn,
-      saveProfilePicture(['profilePicture', 'coverPicture']),
-      // filesToBody,
+      applyProfileMediaKeys,
     ],
     update: disallow(),
     patch: [
       LimitToOwner,
-      saveProfilePicture(['profilePicture', 'coverPicture']),
+      applyProfileMediaKeys,
     ],
     remove: [LimitToOwner],
   },

--- a/src/services/communities/communities.service.ts
+++ b/src/services/communities/communities.service.ts
@@ -8,7 +8,6 @@ import { Communities } from './communities.class';
 import { Community } from '../../database/communities';
 import { CommunityUser } from '../../database/community-users';
 import { CommunityBan } from '../../database/community-bans';
-import { postStorage as profilesStorage } from '../../storage/s3';
 import updateTheTSVector from '../search/tsquery-and-search.hook';
 import communityJoinHooks from '../community-join/community-join.hooks'
 import {CommunityUsers} from '../community-users/community-users.class'
@@ -16,7 +15,6 @@ import communityUsersHooks from '../community-users/community-users.hooks'
 import {CommunityJoinRequest} from '../community-join/community-join.class'
 import {CommunityBans} from '../community-bans/community-bans.class'
 import communityBansHooks from '../community-bans/community-bans.hooks'
-import fileToFeathers from '../../middleware/PassFilesToFeathers/file-to-feathers.middleware';
 import {CommunityJoinRequest as CommunityJoinRequestModel} from '../../database/communityJoinRequest'
 import {CommunityInvitationRequest as InvitationModel} from '../../database/communityInvitationRequest';
 import {CommunityInvitationRequest  } from '../community-invitation-request/community-invitation-request.class'
@@ -61,16 +59,11 @@ export default function (app: Application): void {
     paginate:app.get('paginate')
   }
 
-  // Initialize our service with any options it requires
-  app.use(
-    '/communities',
-    profilesStorage.fields([
-      { name: 'profilePicture', maxCount: 1 },
-      { name: 'coverPicture', maxCount: 1 },
-    ]),
-    fileToFeathers,
-    new Communities(communityOptions, app)
-  );
+  // Direct registration — no multer/multipart middleware. Profile/cover
+  // pictures land via the presign flow handled by applyProfileMediaKeys
+  // in communities.hooks.ts (clients send profilePictureKey/coverPictureKey
+  // in the JSON body of POST/PATCH /communities).
+  app.use('/communities', new Communities(communityOptions, app));
 
   app.use('/communities/:communityId/members', new CommunityUsers(communityUsersOptions, app))
   app.use('/communities/:communityId/joinRequest', new CommunityJoinRequest(communityJoinOptions, app))


### PR DESCRIPTION
## Summary

Removes multipart-upload handling from the communities service. Reuses the `applyProfileMediaKeys` hook introduced in VWA-127 — same shape, no new code needed (the hook is generic over `profilePictureKey` / `coverPictureKey`).

[VWA-128](https://linear.app/vwanu/issue/VWA-128) · stacks on [#65 (VWA-127 BE)](https://github.com/Vwanu/vwanu-api/pull/65) · parent [VWA-88](https://linear.app/vwanu/issue/VWA-88)

Mobile companion: PR opening on `vwanu-mobile-application` next.

## What changed

- **`src/services/communities/communities.service.ts`** — drop `profilesStorage.fields(...)` multer middleware and `fileToFeathers` middleware. Plain `app.use('/communities', new Communities(...))`.
- **`src/services/communities/communities.hooks.ts`** — replace `saveProfilePicture(['profilePicture', 'coverPicture'])` (multer-driven, on both `create` and `patch`) with `applyProfileMediaKeys` (presign-key driven). The hook handles both fields automatically.

## Why no class-level changes

`Communities.create()` and `Communities.patch()` already do their own JSON handling for `interests`. The hook runs as a `before` hook so all field resolution happens before the class methods see the data — the class is none the wiser whether the data came from multipart bytes or a JSON body.

## Smoke test plan post-merge

- POST `/communities` with `{ name, description, interests, profilePictureKey: 'community/2026/05/04/<uuid>.jpg' }` → community created, `profilePicture` column holds the resolved public URL.
- PATCH `/communities/{id}` with `{ profilePictureKey: 'community/...' }` → updates the URL.
- POST with arbitrary `random/etc.jpg` → 400 "must start with one of: ...".
- POST with a non-existent key → 400 "Media not found in S3".
- POST with no `profilePictureKey` (text-only community) → still works, picture stays null/default.

## Out of scope

- VWA-133's URL-vs-key DB convention — this PR still writes the resolved public URL via `applyProfileMediaKeys`. Once VWA-133 lands, the hook will write the key directly (single-line tweak in the hook, separate coordination).