### PR TITLE
VWA-137:Drop unused users.coverPicture column (BE)

### DIFF
--- a/migrations/20260504060000-drop-users-cover-picture.js
+++ b/migrations/20260504060000-drop-users-cover-picture.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * VWA-137 — drop unused users.cover_picture column.
+ *
+ * No screen / feature consumes this column. Confirmed during VWA-127
+ * (registration profile screen handles only profilePicture) and VWA-133
+ * (mobile codebase has zero reads of users.coverPicture). Carrying it
+ * was wasting a backfill in VWA-133 and adding noise to types/hooks.
+ */
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.removeColumn('users', 'cover_picture');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.addColumn('users', 'cover_picture', {
+      type: Sequelize.STRING,
+      allowNull: true,
+      defaultValue:
+        'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?ixlib=rb-1.2.1&auto=format&fit=crop&w=1920&q=80',
+    });
+  },
+};

--- a/src/database/user.ts
+++ b/src/database/user.ts
@@ -128,14 +128,6 @@ export class User extends Model<UserInterface> {
   profilePicture: string;
 
   @Column({
-    type: DataType.STRING,
-    allowNull: true,
-    defaultValue: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?ixlib=rb-1.2.1&auto=format&fit=crop&w=1920&q=80',
-    field:'cover_picture',
-  })
-  coverPicture: string;
-
-  @Column({
    type: DataType.TEXT,
   allowNull: true,
   field: 'search_vector',


### PR DESCRIPTION
## Summary

Drops the `users.cover_picture` column. No screen / feature consumes it. Confirmed during VWA-127 (registration profile screen handles only `profilePicture`) and VWA-133 (zero `users.coverPicture` reads in the mobile codebase).

[VWA-137](https://linear.app/vwanu/issue/VWA-137) · stacks on [#65 (VWA-127 BE)](https://github.com/Vwanu/vwanu-api/pull/65) · parent [VWA-88](https://linear.app/vwanu/issue/VWA-88)

## What changed

- **`migrations/20260504060000-drop-users-cover-picture.js`** (new): `removeColumn('users', 'cover_picture')`. Down-migration re-adds it as nullable with the original Unsplash default.
- **`src/database/user.ts`**: drop the `coverPicture` field from the `User` class.

## Why no hook change

The shared `applyProfileMediaKeys` hook still handles `coverPictureKey` because **communities** legitimately have a cover picture (used by VWA-128). Stripping it from the hook would break that. If a stale client somehow sends `coverPictureKey` to `/users` after this lands, the request will 500 at the Sequelize layer — acceptable, since no current client does that.

## Mobile-side scope

`User` / `Profile` types in `types.d.ts` already don't include `coverPicture` (was never typed). No mobile PR needed.

## Test plan post-merge

- `sequelize db:migrate` runs cleanly on dev DB; `\d users` no longer shows `cover_picture`.
- Existing user-affecting flows (registration profile picture, name updates, etc.) continue to work.
- Community profile + cover picture flows continue to work via VWA-128.

## Risk

Dev-only — no prod yet, so the destructive column drop is safe.