### PR TITLE
Hotfix:Drop isUrl validator on Community.profilePicture (post-VWA-133)

### DIFF
--- a/src/database/communities.ts
+++ b/src/database/communities.ts
@@ -105,11 +105,10 @@ export class Community extends Model<CommunityInterface> {
     type: DataType.STRING,
     allowNull: true,
     field: 'profile_picture',
-    validate: {
-      isUrl: {
-        msg: 'Profile picture must be a valid URL'
-      }
-    },
+    // Stores the S3 key (e.g. `community/2026/05/09/<uuid>.jpg`) — VWA-133.
+    // Mobile builds the rendered URL via cdnImageUrl(key, preset).
+    // External URLs (UI-Avatars defaults / legacy) also pass through; no
+    // validation here since both shapes are valid.
   })
   profilePicture!: string;
 


### PR DESCRIPTION
## Symptom

\`POST /communities\` (and \`PATCH /communities/{id}\`) returns 500:

\`\`\`
ValidationError: Validation error: Profile picture must be a valid URL
  validatorKey: 'isUrl'
  value: 'community/2026/05/09/270bf838-ce3f-4c38-a134-ccf69c0aa64e.jpg'
\`\`\`

## Cause

The \`Community\` Sequelize model on \`src/database/communities.ts\` still had a \`validate: { isUrl: true }\` on \`profilePicture\`. After VWA-133 we now write the bare S3 key into that column (mobile builds the URL via \`cdnImageUrl\`), so any community create/edit fails the \`isUrl\` check.

## Fix

Drop the validator. The column accepts either:
- An S3 key (\`community/2026/05/09/<uuid>.jpg\`) — new shape post-VWA-133
- An external URL (legacy multipart uploads, UI-Avatars defaults)

Both are valid by intent; no point validating.

## Out of scope (intentional)

\`forums\` and \`forumCategories\` models also have \`isUrl\` validators on cover-picture columns. Not part of the upload-migration scope; leave them alone — they'll need similar fixes whenever those features migrate, but not blocking today.

## Mobile companion

[vwanu-mobile-application Hotfix PR](https://github.com/Vwanu/vwanu-mobile-application/pulls) — wraps community card image rendering through \`cdnImageUrl\`.

## Test plan

- [ ] \`POST /communities\` with \`{ name, description, interests, profilePictureKey: 'community/...' }\` → 201, picture key persisted.
- [ ] \`PATCH /communities/{id}\` with \`{ profilePictureKey }\` → updates.
- [ ] Existing communities (URL or key in column) still readable + renderable.